### PR TITLE
Add class selector to table row.

### DIFF
--- a/source/scrape.js
+++ b/source/scrape.js
@@ -15,7 +15,7 @@ module.exports = (osmosis, url, followRedirects = true, hide = false, results = 
     .data(data => { score = data.score })
     .find(`.reportSection`)
     .set(`section`, `.reportTitle`)
-    .select(`.reportTable tr`)
+    .select(`.reportTable tr.tableRow`)
     .set({
       key: `.tableLabel`,
       value: `.tableCell`


### PR DESCRIPTION
The source markup has been updated to include a class "tableRow". This fixes an issue with 'undefined' key.